### PR TITLE
don't show headings in aria-hidden or display: none;

### DIFF
--- a/documentoutline/documentoutline.js
+++ b/documentoutline/documentoutline.js
@@ -1,25 +1,57 @@
 // Document Outline
 
 {
-  console.clear()
+  console.clear();
 
   console.log(`Document outline:`);
 
-  const headings = document.querySelectorAll('h1, h2, h3, h4, h5, h6, [role="heading"]');
-  for(let i = 0; i < headings.length; i++) {
+  const headings = document.querySelectorAll(
+    'h1, h2, h3, h4, h5, h6, [role="heading"]'
+  );
+  let totalHeadings = 0;
+
+  for (let i = 0; i < headings.length; i++) {
     const heading = headings[i];
-    var level;
-    if (heading.getAttribute('role')=='heading') {
-      level = heading.hasAttribute('aria-level') ? parseInt(heading.getAttribute('aria-level')) : 2;
+    let inAriaHidden = false;
+    let parent = heading.parentElement;
+    let level;
+
+    if (heading.getAttribute("role") === "heading") {
+      level = heading.hasAttribute("aria-level")
+        ? parseInt(heading.getAttribute("aria-level"), 10)
+        : 2;
     } else {
-      level = parseInt(heading.nodeName.replace('H', ''));
+      level = parseInt(heading.nodeName.replace("H", ""), 10);
     }
 
-    console.log(`%c<${heading.nodeName}> ${heading.textContent.replace(/\s\s+/g, ' ').trim()} ${(heading.getAttribute('role')=='heading') ? '(aria-level = ' + level + ')' : '' }`, `padding-left: ${(level * 30)}px; font-size: ${27 - (level * 3)}px`)
+    while (parent && !inAriaHidden) {
+      const isCSSHidden = window.getComputedStyle(parent).display === "none";
+      const isAriaHidden = parent.getAttribute("aria-hidden");
+      if (isAriaHidden === "true" || isCSSHidden) {
+        inAriaHidden = true;
+        break;
+      }
+      parent = parent.parentElement;
+    }
+
+    if (inAriaHidden) {
+      continue;
+    }
+
+    totalHeadings += 1;
+
+    const consoleMessage = `%c<${heading.nodeName}> ${heading.textContent
+      .replace(/\s\s+/g, " ")
+      .trim()} ${heading.getAttribute("role") === "heading"
+      ? `(aria-level = ${level})`
+      : ""}`;
+    const consoleStyle = `padding-left: ${level * 30}px; font-size: ${27 -
+      level * 3}px`;
+
+    console.log(consoleMessage, consoleStyle);
   }
 
-  console.log('---------')
-
-  var done = 'Finished running “Doc Outline"'
-  done;
+  console.log("---------");
+  console.log("# of headings: ", totalHeadings);
+  console.log('Finished running “Doc Outline"');
 }


### PR DESCRIPTION
Currently the document outline script shows all headings even if they are in an `aria-hidden="true"` or `display: none;` block. This update removes them from the outline and only prints what the VO Rotor would see. 

Additionally, I added the total number of headings to be displayed at the bottom of the script. It's just a little more information to make the script a little more valueable.